### PR TITLE
Updates MeSH parser for 2025 release.

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 This PHP code library provides tools for extracting [Medical Subject Headings](https://www.nlm.nih.gov/mesh/meshhome.html) 
 (MeSH) descriptors and associated data from a given XML file into an object representation.
 
-It expects its input to be compliant with the 2023 or 2024 [MeSH DTDs](https://www.nlm.nih.gov/databases/download/mesh.html).
+It expects its input to be compliant with the 2024 or 2025 [MeSH DTDs](https://www.nlm.nih.gov/databases/download/mesh.html).
 
 ## Installation
 

--- a/src/Ilios/MeSH/Model/Concept.php
+++ b/src/Ilios/MeSH/Model/Concept.php
@@ -14,8 +14,6 @@ class Concept extends Reference
 
     protected ?string $casn1Name = null;
 
-    protected ?string $registryNumber = null;
-
     protected ?string $scopeNote = null;
 
     protected ?string $translatorsEnglishScopeNote = null;
@@ -27,6 +25,8 @@ class Concept extends Reference
     protected array $conceptRelations = [];
 
     protected array $terms = [];
+
+    protected array $registryNumbers = [];
 
     public function isPreferred(): bool
     {
@@ -46,16 +46,6 @@ class Concept extends Reference
     public function setCasn1Name(?string $casn1Name): void
     {
         $this->casn1Name = $casn1Name;
-    }
-
-    public function getRegistryNumber(): ?string
-    {
-        return $this->registryNumber;
-    }
-
-    public function setRegistryNumber(?string $registryNumber): void
-    {
-        $this->registryNumber = $registryNumber;
     }
 
     public function getScopeNote(): ?string
@@ -116,5 +106,15 @@ class Concept extends Reference
     public function addTerm(Term $term): void
     {
         $this->terms[] = $term;
+    }
+
+    public function getRegistryNumbers(): array
+    {
+        return $this->registryNumbers;
+    }
+
+    public function addRegistryNumber(string $registryNumber): void
+    {
+        $this->registryNumbers[] = $registryNumber;
     }
 }

--- a/src/Ilios/MeSH/Parser.php
+++ b/src/Ilios/MeSH/Parser.php
@@ -270,7 +270,7 @@ class Parser
                         break;
                     case self::REGISTRY_NUMBER:
                         $number = $this->getNodeContents($reader);
-                        $currentConcept->setRegistryNumber($number);
+                        $currentConcept->addRegistryNumber($number);
                         break;
                     case self::RELATED_REGISTRY_NUMBER:
                         $number = $this->getNodeContents($reader);

--- a/tests/Ilios/MeSH/Model/ConceptTest.php
+++ b/tests/Ilios/MeSH/Model/ConceptTest.php
@@ -44,9 +44,9 @@ class ConceptTest extends BaseTestCase
         $this->basicSetTest($this->object, 'casn1Name', 'string', true);
     }
 
-    public function testGetSetRegistryNumber(): void
+    public function testAddGetRegistryNumbers(): void
     {
-        $this->basicSetTest($this->object, 'registryNumber', 'string', true);
+        $this->addTextToListTest($this->object, 'registryNumber');
     }
 
     public function testGetSetScopeNote(): void

--- a/tests/Ilios/MeSH/ParserTest.php
+++ b/tests/Ilios/MeSH/ParserTest.php
@@ -165,14 +165,19 @@ EOL;
         $this->assertTrue($concept->isPreferred());
         $this->assertEquals('M0000001', $concept->getUi());
         $this->assertEquals('a casn1 name', $concept->getCasn1Name());
-        $this->assertEquals('00000AAAAA', $concept->getRegistryNumber());
+
+        $registryNumbers = $concept->getRegistryNumbers();
+        $this->assertEquals(2, count($registryNumbers));
+        $this->assertEquals('00000AAAAA', $registryNumbers[0]);
+        $this->assertEquals('11111BBBBB', $registryNumbers[1]);
+
         $this->assertEquals('a scope note', $concept->getScopeNote());
         $this->assertEquals('something in English.', $concept->getTranslatorsEnglishScopeNote());
         $this->assertEquals('i got nothing', $concept->getTranslatorsScopeNote());
 
-        $registryNumbers = $concept->getRelatedRegistryNumbers();
-        $this->assertEquals(1, count($registryNumbers));
-        $this->assertEquals('a related registry number', $registryNumbers[0]);
+        $relatedRegistryNumbers = $concept->getRelatedRegistryNumbers();
+        $this->assertEquals(1, count($relatedRegistryNumbers));
+        $this->assertEquals('a related registry number', $relatedRegistryNumbers[0]);
 
         $relations = $concept->getConceptRelations();
         $this->assertEquals(1, count($relations));
@@ -202,7 +207,7 @@ EOL;
         $this->assertFalse($concept->isPreferred());
         $this->assertEquals('M0000002', $concept->getUi());
         $this->assertEquals('another concept', $concept->getName());
-        $this->assertEquals('0', $concept->getRegistryNumber());
+        $this->assertCount(0, $concept->getRegistryNumbers());
 
         $relations = $concept->getConceptRelations();
         $this->assertEquals(1, count($relations));

--- a/tests/Ilios/MeSH/desc.xml
+++ b/tests/Ilios/MeSH/desc.xml
@@ -3,7 +3,7 @@
 Fake MeSH descriptors set, for testing purposes.
 It contains all possible elements defined by the schema.
 -->
-<!DOCTYPE DescriptorRecordSet SYSTEM "https://www.nlm.nih.gov/databases/dtd/nlmdescriptorrecordset_20240101.dtd">
+<!DOCTYPE DescriptorRecordSet SYSTEM "https://www.nlm.nih.gov/databases/dtd/nlmdescriptorrecordset_20250101.dtd">
 <DescriptorRecordSet LanguageCode="eng">
     <DescriptorRecord DescriptorClass="1">
         <DescriptorUI>D000000</DescriptorUI>
@@ -133,7 +133,10 @@ It contains all possible elements defined by the schema.
                     <String>a concept</String>
                 </ConceptName>
                 <CASN1Name>a casn1 name</CASN1Name>
-                <RegistryNumber>00000AAAAA</RegistryNumber>
+                <RegistryNumberList>
+                    <RegistryNumber>00000AAAAA</RegistryNumber>
+                    <RegistryNumber>11111BBBBB</RegistryNumber>
+                </RegistryNumberList>
                 <ScopeNote>a scope note</ScopeNote>
                 <TranslatorsEnglishScopeNote>something in English.</TranslatorsEnglishScopeNote>
                 <TranslatorsScopeNote>i got nothing</TranslatorsScopeNote>
@@ -170,7 +173,6 @@ It contains all possible elements defined by the schema.
                 <ConceptName>
                     <String>another concept</String>
                 </ConceptName>
-                <RegistryNumber>0</RegistryNumber>
                 <ConceptRelationList>
                     <ConceptRelation RelationName="NRW">
                         <Concept1UI>M0000002</Concept1UI>


### PR DESCRIPTION
the DTD for descriptors changed mid-2024, and replaced the single RegistryNumber element in Concept with an optional RegistryNumberList element that can contain multiple RegistryNumber elements.

We don't need fork logic here since this change already went into effect, and we're only supporting the latest 2024 DTD and the 2025 DTD. In other words, a simple drop-in replacement is all we need here.

fixes #83 